### PR TITLE
Mapping of OPP-090 and BT-125 adjusted.

### DIFF
--- a/xslt/lot.xslt
+++ b/xslt/lot.xslt
@@ -653,6 +653,10 @@
 			<xsl:call-template name="include-comment"><xsl:with-param name="comment" select="'Additional Information Deadline (BT-13)'"/></xsl:call-template>
 			<!-- Previous Planning Identifier (BT-125): eForms documentation cardinality (Lot) = ? | The equivalent element(s) in TED are at TED_EXPORT/CODED_DATA_SECTION/NOTICE_DATA/REF_NOTICE/NO_DOC_OJS -->
 			<xsl:call-template name="include-comment"><xsl:with-param name="comment" select="'Previous Planning Identifier (BT-125)'"/></xsl:call-template>
+			<xsl:if test="$eforms-form-type = 'competition'">
+				<xsl:apply-templates select="*:PROCEDURE/*:NOTICE_NUMBER_OJ"/>
+			</xsl:if>
+			
 			<!-- Submission Nonelectronic Justification (BT-19): eForms documentation cardinality (Lot) = ? | No equivalent element in TED XML -->
 			<xsl:call-template name="include-comment"><xsl:with-param name="comment" select="'Submission Nonelectronic Justification (BT-19)'"/></xsl:call-template>
 			<!-- Submission Nonelectronic Description (BT-745): eForms documentation cardinality (Lot) = ? | No equivalent element in TED XML -->

--- a/xslt/procedure.xslt
+++ b/xslt/procedure.xslt
@@ -96,7 +96,7 @@ exclude-result-prefixes="xlink xs xsi fn functx doc opfun ted ted-1 ted-2 gc n20
 <xsl:template match="*:NOTICE_NUMBER_OJ">
 	<xsl:variable name="text" select="fn:normalize-space(.)"/>
 	<cac:NoticeDocumentReference>
-		<cbc:ID schemeName="ojs-notice-id"><xsl:value-of select="$text"/></cbc:ID>
+		<cbc:ID schemeName="ojs-notice-id"><xsl:value-of select="concat(concat(format-number(number(tokenize($text, '-')[2]), '00000000'), '-'), substring($text, 1, 4))"/></cbc:ID>
 	</cac:NoticeDocumentReference>
 </xsl:template>
 

--- a/xslt/ted-to-eforms.xslt
+++ b/xslt/ted-to-eforms.xslt
@@ -334,12 +334,11 @@ exclude-result-prefixes="xlink xs xsi fn functx doc opfun ted ted-1 ted-2 gc n20
 		<!-- PIN Competition Termination (BT-756): eForms documentation cardinality (Procedure) = ? | Optional for CAN subtypes 29, 30, 33, and 34; Forbidden for other subtypes -->
 		<xsl:call-template name="pin-competition-termination"/>
 
-		<!-- Previous Planning Identifier (BT-125): eForms documentation cardinality (Procedure) = - | Forbidden for CM subtypes 38-40 and E5; Optional for other subtypes. -->
-		<xsl:call-template name="include-comment"><xsl:with-param name="comment" select="'Previous Planning Identifier (BT-125)'"/></xsl:call-template>
-		<!-- TBD: Discussion about methods of linking to previous notices is ongoing. This mapping/conversion may change. -->
-		<!-- TBD: When the notice linked to is of type PIN Only, BT-125 and BT-1251 should be specified at Lot level, not at notice level. -->
-
-		<xsl:apply-templates select="*:PROCEDURE/*:NOTICE_NUMBER_OJ"/>
+		<!-- Previous Notice Identifier (OPP-090): Used for linking the competition to the result notice. -->
+		<xsl:call-template name="include-comment"><xsl:with-param name="comment" select="'Previous Notice Identifier (OPP-090)'"/></xsl:call-template>
+		<xsl:if test="$eforms-form-type = 'result'">
+			<xsl:apply-templates select="*:PROCEDURE/*:NOTICE_NUMBER_OJ"/>
+		</xsl:if>
 
 		<!-- Procedure Accelerated (BT-106): eForms documentation cardinality (Procedure) = ? | Optional for CN subtypes 16-18 and E3, CAN subtypes 29-31 and E4, CM subtype E5; Forbidden for other subtypes -->
 		<!-- Procedure Accelerated Justification (BT-1351): eForms documentation cardinality (Procedure) = ? | Optional for CN subtypes 16-18 and E3, CAN subtypes 29-31 and E4, CM subtype E5; Forbidden for other subtypes -->


### PR DESCRIPTION
Hello,

Currently, the converter creates BT-125(1) at procedure level. However, at procedure level, the XML-Structure takes on the meaning of OPP-090, which is used for linking result notices to their completition notice counterpart. I have moved the Mapping of BT-125(1) to lot level and restricted the mapping to competition notices. I have also adjsuted the format of the OJS notice number to match the format described in the SDK.